### PR TITLE
Docs improvements

### DIFF
--- a/contrib/demo-rgb.sh
+++ b/contrib/demo-rgb.sh
@@ -33,7 +33,7 @@ tmux new-session -d -s rgb rgbd -vvv --network testnet
 tmux new-session -d -s storm stormd -vvv --chat --downpour --msg ~/.lnp_node/testnet/msg
 # -OR- run all the daemons within the same terminal (processes must be exited using process manager)
 # Note: Try all these commands separately first to ensure they can run
-stored -vvv & lnpd -vvv --network testnet & rgbd -vvv --network testnet & stormd -vvv --chat --downpour --msg /home/hunter/.lnp_node/testnet/msg &
+stored -vvv & lnpd -vvv --network testnet & rgbd -vvv --network testnet & stormd -vvv --chat --downpour --msg ~/.lnp_node/testnet/msg &
 
 # --- CONTRACT ISSUANCE
 

--- a/contrib/demo-rgb.sh
+++ b/contrib/demo-rgb.sh
@@ -2,13 +2,8 @@
 
 # --- INITIAL SETUP
 
-# Only nightly cargo supports installing binary bundles
-rustup add nigtly
-rustup update nigtly
-# This installs all 4 LNP/BP nodes at onc
-cargo +nightly -Z bindeps install lnpbp_nodes --version 0.8.0-rc.1
-# This installs a dozen of command-line tools for working with LNP/BP stack
-cargo +nightly -Z bindeps install lnpbp-cli --version 0.8.0-rc.1
+# Run separate install script
+./install.sh
 
 DIR=~/.demo # Replace with the desired location
 
@@ -49,10 +44,8 @@ rgb-cli -n testnet contract state ${CONTRACT_ID}
 # ----------------------------------------------------------
 # Go to a remote server / other machine and do the following
 
-rustup add nigtly
-rustup update nigtly
-cargo +nightly -Z bindeps install lnpbp_nodes --version 0.8.0-rc.1
-cargo +nightly -Z bindeps install lnpbp-cli --version 0.8.0-rc.1
+# Run separate install script
+./install.sh
 
 DIR=~/.demo # Replace with the desired location
 

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -8,7 +8,7 @@ cargo install --force --all-features rgb_node --version "0.8.0"
 cargo install --force --all-features storm_node --version "0.8.0"
 cargo install --force --all-features store_daemon --version "0.8.0"
 # This install --forces a dozen of command-line tools for working with LNP/BP stack
-cargo install --force --all-features descriptor-wallet --version "0.8.2"
+cargo install --force --all-features descriptor-wallet --version "0.8.3"
 cargo install --force --all-features bp-core --version "0.8.0"
 cargo install --force --all-features rgb-std --version "0.8.0"
 cargo install --force --all-features rgb20 --version "0.8.0-rc.4"

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -1,0 +1,19 @@
+# Only nightly cargo supports installing binary bundles
+rustup toolchain install nightly
+rustup update nightly
+# This installs all 4 LNP/BP nodes
+cargo install --force --all-features bp_node --version "0.8.0-alpha.2"
+cargo install --force --all-features lnp_node --version "0.8.0"
+cargo install --force --all-features rgb_node --version "0.8.0"
+cargo install --force --all-features storm_node --version "0.8.0"
+cargo install --force --all-features store_daemon --version "0.8.0"
+# This install --forces a dozen of command-line tools for working with LNP/BP stack
+cargo install --force --all-features descriptor-wallet --version "0.8.2"
+cargo install --force --all-features bp-core --version "0.8.0"
+cargo install --force --all-features rgb-std --version "0.8.0"
+cargo install --force --all-features rgb20 --version "0.8.0-rc.4"
+cargo install --force --all-features bp-cli --version "0.8.0-alpha.2"
+cargo install --force --all-features lnp-cli --version "0.8.0"
+cargo install --force --all-features rgb-cli --version "0.8.0"
+cargo install --force --all-features storm-cli --version "0.8.0"
+cargo install --force --all-features store-cli --version "0.8.0"


### PR DESCRIPTION
In addition to the changes in #10, I wanted to add some clarifying information to the demo script for newcomers.

Also, I made use of the code in this branch, which combines that in https://github.com/RGB-WG/rgb-node/pull/194 and https://github.com/RGB-WG/rgb-node/pull/193
https://github.com/cryptoquick/rgb-node/tree/latest

It seems to work fine, and it produced this tx on testnet:
https://mempool.space/testnet/tx/d2e977d29ea1b97b65071fb034d00869863873eee1c319198173f3f8cc2477e2

Not sure if that's optimal or suboptimal in some way. I'd actually appreciate if @zoedberg or @crisdut could double-check.

I also made copies of the PSBTs and contracts in order to better analyze how they evolve over the process.
![Screenshot from 2022-08-23 04-02-34](https://user-images.githubusercontent.com/285690/186133505-5b0a3478-2504-4405-8443-726cf6470c1e.png)
See zip here:
[demo.zip](https://github.com/LNP-BP/nodes/files/9401621/demo.zip)
All sats in that wallet are unspendable now since I forgot to provide a change address maybe, so no harm in providing the wallet password. It's `asdfasdf`.